### PR TITLE
Allow eventum/rpc 3.x and 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
 	"require": {
 		"php": "^5.3.0 || ^7.0",
 		"ext-date": "*",
-		"eventum/rpc": "^3"
+		"eventum/rpc": "^3 || ^4"
 	}
 }


### PR DESCRIPTION
Replaces https://github.com/eventum/dokuwiki-plugin-eventum/pull/5 and https://github.com/eventum/dokuwiki-plugin-eventum/pull/8